### PR TITLE
fix error when updating invalid token

### DIFF
--- a/src/modules/data/DBConnect.js
+++ b/src/modules/data/DBConnect.js
@@ -130,6 +130,10 @@ const update_login = async (version) => {
                     })
                 }
                 break
+            case 204:
+                // the stored token is invalid, clear local storage
+                localStorage.clear()
+                break
             case 404:
                 break
             default:


### PR DESCRIPTION
Sometimes the token changes, so the stored old one is invalid. clear the local storage, so the user can login
