### PR TITLE
BottomMenu: Adds padding for safe area in bottom menu

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -2,7 +2,7 @@ import { createGlobalStyle } from "styled-components"
 
 export const GlobalStyles = createGlobalStyle`
     html, body {
-        margin: 0;
+        margin: env(safe-area-inset-top), env(safe-area-inset-right), env(safe-area-inset-bottom), env(safe-area-inset-left);
         padding: 0;
     }
     *, *::after, *::before {
@@ -30,7 +30,7 @@ export const GlobalStyles = createGlobalStyle`
         color: ${({theme}) => theme.primaryLight};
         display: block;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-        height: 100vh;
+        // height: 100vh;
         justify-content: flex-start;
         text-rendering: optimizeLegibility;
         forced-color-adjust: none;

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,3 @@
-body {
-  margin: env(safe-area-inset);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 body {
-  margin: 0;
+  margin: env(safe-area-inset);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/src/modules/components/menu/BottomMenu.styled.js
+++ b/src/modules/components/menu/BottomMenu.styled.js
@@ -12,6 +12,7 @@ export const StyledBottomMenu = styled.footer`
 
     @media (max-width: ${({theme}) => theme.mobile}) {
         display: flex;
+        padding-bottom: env(safe-area-inset-bottom);
     }
 `
 

--- a/src/modules/components/menu/BottomMenu.styled.js
+++ b/src/modules/components/menu/BottomMenu.styled.js
@@ -12,7 +12,6 @@ export const StyledBottomMenu = styled.footer`
 
     @media (max-width: ${({theme}) => theme.mobile}) {
         display: flex;
-        margin-bottom: env(safe-area-inset-bottom);
     }
 `
 

--- a/src/modules/components/menu/BottomMenu.styled.js
+++ b/src/modules/components/menu/BottomMenu.styled.js
@@ -12,7 +12,7 @@ export const StyledBottomMenu = styled.footer`
 
     @media (max-width: ${({theme}) => theme.mobile}) {
         display: flex;
-        padding-bottom: env(safe-area-inset-bottom);
+        margin-bottom: env(safe-area-inset-bottom);
     }
 `
 


### PR DESCRIPTION
Adds padding to the bottom menu to account for the safe area on devices with a bottom navigation bar.

This ensures that the menu items are not obscured by the system UI.
