### PR TITLE
Fix apple splash link typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
     />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="apple-touch-icon" href="/favicon.ico" />
-    <link
-      ref="/apple_splash_1125.png"
-      media="screen (device-width: 375px) and (device-heigth: 812px) and (-webkit-device-pixel-ration: 3) and (orientation: portrait)"
-      rel="apple-touch-startup-image"/>
+  <link
+    href="/apple_splash_1125.png"
+    media="screen (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"
+    rel="apple-touch-startup-image"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
## Summary
- correct attribute names and values in apple splash link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68500999fbcc832185cb4ae73a906df2