### PR TITLE
Fix deletion condition in AbsenceForm

### DIFF
--- a/src/components/absenceadministration/absenceform/AbsenceForm.jsx
+++ b/src/components/absenceadministration/absenceform/AbsenceForm.jsx
@@ -194,14 +194,13 @@ const Form = ({selected, reload}) => {
     }
 
     const delAbsence = async (e) => {
-        
-        e.preventDefault()
-        
-        if(absence.Absence_ID > 0)
 
-            return true
+        e.preventDefault()
+
+        if(absence.Absence_ID > 0){
             await deleteAbsence(absence.Absence_ID)
-        
+        }
+
         reload()
         clear(e)
     }


### PR DESCRIPTION
## Summary
- fix `delAbsence` so deletions happen correctly when `Absence_ID` is valid

## Testing
- `npm test` *(fails: Missing script)*
- `npx playwright test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6850276967d883219b419e3e788f25b3