### PR TITLE
Fix absence headers

### DIFF
--- a/src/modules/data/DBConnect.js
+++ b/src/modules/data/DBConnect.js
@@ -481,16 +481,16 @@ export const newAbsence = async (from, until, info) => {
 
 	let token = localStorage.getItem("api_token")
 
-	let response = await fetch(`${host}/api/absence.php?api_token=${token}`, {
-		method: "POST",
-		header: {
-			"content-type": "application/json"
-		},
-		body: JSON.stringify({
-			From: from,
-			Until: until,
-			Info: info
-		})
+       let response = await fetch(`${host}/api/absence.php?api_token=${token}`, {
+               method: "POST",
+               headers: {
+                       "content-type": "application/json"
+               },
+               body: JSON.stringify({
+                       From: from,
+                       Until: until,
+                       Info: info
+               })
 	})
 	switch(response.status){
 	case 201:
@@ -505,17 +505,17 @@ export const newManualAbsence = async (member_id, from, until, info) => {
     
 	let token = localStorage.getItem("api_token")
 
-	let response = await fetch(`${host}/api/absence.php?api_token=${token}`, {
-		method: "POST",
-		header: {
-			"content-type": "application/json"
-		},
-		body: JSON.stringify({
-			Member_ID:  member_id,
-			From:       from,
-			Until:      until,
-			Info:       info
-		})
+       let response = await fetch(`${host}/api/absence.php?api_token=${token}`, {
+               method: "POST",
+               headers: {
+                       "content-type": "application/json"
+               },
+               body: JSON.stringify({
+                       Member_ID:  member_id,
+                       From:       from,
+                       Until:      until,
+                       Info:       info
+               })
 	})
 
 	switch(response.status) {


### PR DESCRIPTION
## Summary
- correct header option in newAbsence and newManualAbsence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_b_685027964afc8321997da46d0f6080c5