### PR TITLE
Fix apple touch startup image media attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="apple-touch-icon" href="/favicon.ico" />
   <link
     href="/apple_splash_1125.png"
-    media="screen (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"
+    media="screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"
     rel="apple-touch-startup-image"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
## Summary
- add missing `and` in apple-touch startup media query

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_685027d61f048321ad179bbcbf3e0aaa