### PR TITLE
Fix PWA bottom menu layout on iPhone

### DIFF
--- a/src/modules/components/menu/BottomMenu.styled.js
+++ b/src/modules/components/menu/BottomMenu.styled.js
@@ -5,7 +5,8 @@ export const StyledBottomMenu = styled.footer`
     bottom: 0;
     display: none;
     justify-content: space-around;
-    height: 3rem;
+    height: calc(3rem + env(safe-area-inset-bottom));
+    padding-bottom: env(safe-area-inset-bottom);
     width: 100%;
     background-color: ${({theme}) => theme.primaryDark};
     z-index: 8;


### PR DESCRIPTION
## Summary
- fix bottom menu CSS to account for the safe area insets

## Testing
- `npx playwright test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6851407ef6f08321a4c4d47d8169c13b