### PR TITLE
Center attendence form via styled component

### DIFF
--- a/src/components/dateplanner/Dateplanner.css
+++ b/src/components/dateplanner/Dateplanner.css
@@ -6,11 +6,6 @@
     height: calc(10px + 2vmin);
   }
 
-  .DateInput {
-    width: fit-content;
-    justify-content: center;
-  }
-  
   .Tz {
     text-align: center;
   }

--- a/src/components/dateplanner/attendenceInput/Termineingabe.jsx
+++ b/src/components/dateplanner/attendenceInput/Termineingabe.jsx
@@ -44,7 +44,7 @@ const Termineingabe = ({theme}) => {
     }, [])
 
     return(
-        <Form className="DateInput">
+        <Form>
             <div className='EventFilter'>
                 <select name='eventSelect' id='eventSelect' title='event select' onChange={onEventFilterChange}>
                     <option value='all'>Alle</option>
@@ -69,8 +69,11 @@ const Termineingabe = ({theme}) => {
 }
 
 const Form = styled.form`
-
+    display: flex;
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: fit-content;
 
     @media (max-width: ${({theme}) => theme.mobile}) {
         padding-bottom: 2rem;


### PR DESCRIPTION
## Summary
- center the attendence input form by moving layout rules into the styled Form component
- remove the unused DateInput class styling that previously handled centering

## Testing
- `npx playwright test --project="chromium" --project="Mobile Chrome"` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED while reaching https://spzroenkhausen.bplaced.net)*

------
https://chatgpt.com/codex/tasks/task_b_68d15bbdf6148321baba64f00fc5fd93