### PR TITLE
Consolidate body typography styles

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -29,11 +29,17 @@ export const GlobalStyles = createGlobalStyle`
         background: ${({theme}) => theme.primaryDark};
         color: ${({theme}) => theme.primaryLight};
         display: block;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         height: 100vh;
         justify-content: flex-start;
         text-rendering: optimizeLegibility;
         forced-color-adjust: none;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+    }
+
+    code {
+        font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
     }
 
     button {

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,3 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;


### PR DESCRIPTION
## Summary
- move the global body typography and smoothing rules into the styled-components GlobalStyles definition
- remove the duplicate body declarations from the static index.css so it only provides the code font stack

## Testing
- npm run start -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_b_68d15bcbe5e08321badd04ae17b4f1c6