### PR TITLE
Add notification block hint on dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { themes } from './theme';
 import { TbBellFilled, TbBellOff } from 'react-icons/tb';
 import Settings from './components/settings/Settings';
 import { notificationHelper } from './modules/helper/NotificationHelper';
+import { persistNotificationPermissions } from './modules/helper/NotificationPermissionsStorage';
 import { buttonPressed } from './modules/helper/Analytics';
 import { Weather } from './modules/components/weather/Weather';
 import { BottomMenu } from './modules/components/menu/BottomMenu';
@@ -62,7 +63,8 @@ const App = () => {
                         notificationHelper.createNotificationSubscription('BD0AbKmeW7bACNzC9m0XSUddJNx--VoOvU2X0qBF8dODOBhHvFPjrKJEBcL7Yk07l8VpePC1HBT7h2FRK3bS5uA')
                         .then(subscription => {
                             sendPushSubscription(subscription).then(permissions => {
-                                setNotify(permissions.Allowed === 1)
+                                persistNotificationPermissions(permissions)
+                                setNotify(permissions?.Allowed === 1)
                             })
                         })
                     }
@@ -97,7 +99,8 @@ const App = () => {
                     notificationHelper.createNotificationSubscription('BD0AbKmeW7bACNzC9m0XSUddJNx--VoOvU2X0qBF8dODOBhHvFPjrKJEBcL7Yk07l8VpePC1HBT7h2FRK3bS5uA')
                     .then(subscription => {
                         sendPushSubscription(subscription).then(permissions => {
-                            setNotify(permissions.Allowed === 1)
+                            persistNotificationPermissions(permissions)
+                            setNotify(permissions?.Allowed === 1)
                         })
                     })
                 }
@@ -147,11 +150,7 @@ const App = () => {
         }
 
         if(permissions){
-            try {
-                localStorage.setItem('permissions', JSON.stringify(permissions))
-            } catch (storageError) {
-                console.error(storageError)
-            }
+            persistNotificationPermissions(permissions)
         }
 
         if(permissions?.Allowed === 1){

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -146,6 +146,14 @@ const App = () => {
             return
         }
 
+        if(permissions){
+            try {
+                localStorage.setItem('permissions', JSON.stringify(permissions))
+            } catch (storageError) {
+                console.error(storageError)
+            }
+        }
+
         if(permissions?.Allowed === 1){
             setNotify(true)
             return

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -12,6 +12,7 @@ import EventInfo from './eventinfo/EventInfo'
 import Statistics from './statistics/Statistics'
 import NextEvent from './events/NextEvent'
 import { Changelog } from './Changelog'
+import { readStoredNotificationPermissions } from '../../modules/helper/NotificationPermissionsStorage'
 
 const Button = lazy(() => import('../../modules/components/button/Button'))
 
@@ -119,21 +120,17 @@ const Dashboard = ({ fullname, auth_level, theme }) => {
 
     useEffect(() => {
         const evaluateNotificationPermissions = () => {
-            try {
-                const storedPermissionsRaw = localStorage.getItem('permissions')
-                if(!storedPermissionsRaw){
-                    setNotificationsBlocked(false)
-                    return
-                }
-                const storedPermissions = JSON.parse(storedPermissionsRaw)
-                const permissionStatus = window.Notification?.permission
-                const browserBlocked = permissionStatus !== 'granted'
-                const storedBlocked = storedPermissions?.Notification === -1 || storedPermissions?.Notifications === -1
-                setNotificationsBlocked(Boolean(browserBlocked && storedBlocked))
-            } catch (error) {
-                console.error(error)
+            const storedPermissions = readStoredNotificationPermissions()
+            if(!storedPermissions){
                 setNotificationsBlocked(false)
+                return
             }
+
+            const permissionStatus = window.Notification?.permission
+            const browserBlocked = permissionStatus !== 'granted'
+            const storedBlocked = storedPermissions?.Notification === -1 || storedPermissions?.Notifications === -1
+
+            setNotificationsBlocked(Boolean(browserBlocked && storedBlocked))
         }
 
         evaluateNotificationPermissions()

--- a/src/components/dashboard/Dashboard.styled.js
+++ b/src/components/dashboard/Dashboard.styled.js
@@ -88,6 +88,29 @@ export const StyledInfoText = styled.p`
     }
 `
 
+export const StyledNotificationHint = styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75em;
+    margin: 0 1em 1.5em;
+    padding: 0.75em 1em;
+    width: calc(100% - 2em);
+    max-width: 450px;
+    border-radius: 8px;
+    border-left: 4px solid ${({theme}) => theme.yellow};
+    background-color: rgba(0, 0, 0, 0.05);
+    color: ${({theme}) => theme.primaryDark};
+    font-size: 0.9em;
+    line-height: 1.4;
+
+    svg {
+        flex-shrink: 0;
+        width: 1.4em;
+        height: 1.4em;
+        color: ${({theme}) => theme.yellow};
+    }
+`
+
 export const StyledChangelog = styled.div`
     font-size: smaller;
     padding-inline-start: 1.5em;

--- a/src/modules/helper/NotificationPermissionsStorage.js
+++ b/src/modules/helper/NotificationPermissionsStorage.js
@@ -1,0 +1,28 @@
+export const NOTIFICATION_PERMISSIONS_STORAGE_KEY = 'notificationPermissions'
+
+export const readStoredNotificationPermissions = () => {
+    try {
+        const storedValue = localStorage.getItem(NOTIFICATION_PERMISSIONS_STORAGE_KEY)
+        if(!storedValue){
+            return null
+        }
+
+        return JSON.parse(storedValue)
+    } catch (error) {
+        console.error(error)
+        return null
+    }
+}
+
+export const persistNotificationPermissions = (permissions) => {
+    try {
+        if(permissions){
+            localStorage.setItem(NOTIFICATION_PERMISSIONS_STORAGE_KEY, JSON.stringify(permissions))
+            return
+        }
+
+        localStorage.removeItem(NOTIFICATION_PERMISSIONS_STORAGE_KEY)
+    } catch (error) {
+        console.error(error)
+    }
+}


### PR DESCRIPTION
## Summary
- persist the latest permission settings whenever a notification subscription is updated
- surface a subtle dashboard hint informing users when the browser auto-blocked notifications
- add styling for the new hint so it blends into the start page layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d2b0810c9c8321995475c005408e17