### PR TITLE
Prevent repeated notification permission alerts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -216,7 +216,7 @@ const App = () => {
             </header> : <></>}
             <StyledApp className="App">
                 {theme.weather ? <Weather /> : <></>}
-                {fullname !== "" ? <Burger open={open} setOpen={setOpen} onNotificationEnabled={handleNotificationSubscription}/> : <></>}
+                {fullname !== "" ? <Burger open={open} setOpen={setOpen}/> : <></>}
                 <Menu open={open} setOpen={setOpen} navigate={navigate} auth_level={auth_level} secure={secure.current}/>
                 <Suspense fallback={<div>Lädt...</div>}>
                     <View view={view} sendLogin={sendLogin} fullname={fullname} auth_level={auth_level} theme={theme} secure={secure.current}/>

--- a/src/modules/components/burger/Burger.jsx
+++ b/src/modules/components/burger/Burger.jsx
@@ -1,39 +1,9 @@
 import React from 'react'
 import { StyledBurger } from "./Burger.styled"
-import { notificationHelper } from '../../helper/NotificationHelper'
-import { sendPushSubscription } from '../../data/DBConnect'
+const Burger = ({ open, setOpen }) => {
 
-const Burger = ({ open, setOpen, onNotificationEnabled }) => {
-
-    const notifyCallback = (result) => {
-        if(typeof onNotificationEnabled === 'function'){
-            onNotificationEnabled(result)
-        }
-    }
-
-    const onClick = async () => {
+    const onClick = () => {
         setOpen(!open)
-
-        if(!window.Notification?.requestPermission){
-            notifyCallback({ error: new Error('Notifications are not supported on this device.') })
-            return
-        }
-
-        try {
-            const permission = await window.Notification.requestPermission()
-            if(permission !== 'granted'){
-                notifyCallback({ error: new Error('Notification permission was not granted.') })
-                return
-            }
-
-            const subscription = await notificationHelper.createNotificationSubscription('BD0AbKmeW7bACNzC9m0XSUddJNx--VoOvU2X0qBF8dODOBhHvFPjrKJEBcL7Yk07l8VpePC1HBT7h2FRK3bS5uA')
-            const permissions = await sendPushSubscription(subscription, true)
-
-            notifyCallback({ permissions })
-        } catch (error) {
-            console.error('Failed to send push subscription', error)
-            notifyCallback({ error })
-        }
     }
 
     return(


### PR DESCRIPTION
## Summary
- stop the burger menu from requesting notification permissions when toggled
- ensure notification settings only save after confirming browser permission and inform the user when activation is blocked
- keep the header bell as the trigger for notification permission requests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d393c7bb508321b02b1064248523f2