### PR TITLE
DBConnect: Ensure getEvalByUsergroup always returns an array

### DIFF
--- a/src/modules/data/DBConnect.js
+++ b/src/modules/data/DBConnect.js
@@ -404,6 +404,7 @@ export const updateAttendence = async (event_id, attendence, plusone) => {
 }
 
 const getEvalByUsergroup = async (usergroup_id) => {
+	let evals = new Array(0)
     
 	let token = localStorage.getItem("api_token")
 
@@ -412,10 +413,12 @@ const getEvalByUsergroup = async (usergroup_id) => {
 	})
 	switch(response.status){
 	case 200:
-		return await response.json()
+		evals = await response.json()
+		break
 	default:
-		return
+		break
 	}    
+	return evals
 }
 
 /**


### PR DESCRIPTION
Initialize the evaluations variable as an empty array to provide a consistent return type and prevent errors in the calling code when the API response is not successful.
